### PR TITLE
Fix of the issue #3: Ignored Ukrainian letters

### DIFF
--- a/src/main/java/ua/com/yatran/helpers/GameContext.java
+++ b/src/main/java/ua/com/yatran/helpers/GameContext.java
@@ -94,7 +94,7 @@ public class GameContext {
      */
     public static char[] getAllKeys(Language language) {
         ResourceBundle rb = ResourceBundle.getBundle(Constants.Common.LOCALE_PREFIX, language.getLocale());
-        String result = rb.getString("key_list") + " ";
+        String result = rb.getString("key_list");
         return result.toCharArray();
     }
 

--- a/src/main/java/ua/com/yatran/helpers/GameContext.java
+++ b/src/main/java/ua/com/yatran/helpers/GameContext.java
@@ -81,6 +81,24 @@ public class GameContext {
     }
 
     /**
+     * Returns all supported in the application languages
+     */
+    public static Language[] getAvailableLanguages() {
+        return Language.values();
+    }
+
+    /**
+     * Returns all needed keys for the specified language
+     *
+     * @param language the language to calculate needed keys for
+     */
+    public static char[] getAllKeys(Language language) {
+        ResourceBundle rb = ResourceBundle.getBundle(Constants.Common.LOCALE_PREFIX, language.getLocale());
+        String result = rb.getString("key_list") + " ";
+        return result.toCharArray();
+    }
+
+    /**
      * Returns all supported in the application levels for the specified language (keyboard).
      * A number of levels are calculated by dividing the existing list of chars by pairs.
      * The first level will contain the first two chars.
@@ -156,7 +174,7 @@ public class GameContext {
     }
 
     /**
-     * Returns randomly created array of characters based on the current level and keyboard preference
+     * Returns randomly created an array of characters based on the current level and keyboard preference
      */
     public static String[] getRandomLettersForLevel() {
         String[] resultList = new String[Constants.Game.LEVEL_CHARACTER_SIZE];

--- a/src/main/java/ua/com/yatran/panels/GamePanel.java
+++ b/src/main/java/ua/com/yatran/panels/GamePanel.java
@@ -1,6 +1,7 @@
 package ua.com.yatran.panels;
 
 import ua.com.yatran.constants.Constants;
+import ua.com.yatran.enums.Language;
 import ua.com.yatran.helpers.GameContext;
 import ua.com.yatran.interfaces.AbstractGamePanel;
 import ua.com.yatran.panels.games.FallingCeilingGamePanel;
@@ -12,8 +13,6 @@ import javax.sound.sampled.*;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
-import java.awt.event.InputEvent;
-import java.awt.event.KeyEvent;
 import java.io.IOException;
 import java.util.Calendar;
 import java.util.Objects;
@@ -34,109 +33,8 @@ public class GamePanel extends JPanel {
         this.contentPane = contentPane;
         this.rankingPanel = rankingPanel;
         this.setLayout(null);
-        Action actionListener = new AbstractAction() {
-            public void actionPerformed(ActionEvent actionEvent) {
-                checkKeyPressed(actionEvent.getActionCommand());
-            }
-        };
 
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_BACK_QUOTE, 0), "Key `", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_1, 0), "Key 1", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_2, 0), "Key 2", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_3, 0), "Key 3", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_4, 0), "Key 4", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_5, 0), "Key 5", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_6, 0), "Key 6", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_7, 0), "Key 7", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_8, 0), "Key 8", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_9, 0), "Key 9", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_0, 0), "Key 0", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_MINUS, 0), "Key -", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_EQUALS, 0), "Key =", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_Q, 0), "Key q", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_W, 0), "Key w", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_E, 0), "Key e", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_R, 0), "Key r", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_T, 0), "Key t", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_Y, 0), "Key y", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_U, 0), "Key u", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_I, 0), "Key i", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_O, 0), "Key o", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_P, 0), "Key p", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_OPEN_BRACKET, 0), "Key [", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_CLOSE_BRACKET, 0), "Key ]", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_BACK_SLASH, 0), "Key Backslash", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_A, 0), "Key a", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_S, 0), "Key s", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_D, 0), "Key d", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_F, 0), "Key f", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_G, 0), "Key g", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_H, 0), "Key h", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_J, 0), "Key j", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_K, 0), "Key k", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_L, 0), "Key l", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_SEMICOLON, 0), "Key ;", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_QUOTE, 0), "Key '", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_Z, 0), "Key z", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_X, 0), "Key x", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_C, 0), "Key c", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_V, 0), "Key v", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_B, 0), "Key b", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_N, 0), "Key n", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_M, 0), "Key m", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_COMMA, 0), "Key ,", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_PERIOD, 0), "Key .", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_SLASH, 0), "Key /", actionListener);
-
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_SPACE, 0), "Key Space", actionListener);
-
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_BACK_QUOTE, InputEvent.SHIFT_DOWN_MASK), "Key ~", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_1, InputEvent.SHIFT_DOWN_MASK), "Key !", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_2, InputEvent.SHIFT_DOWN_MASK), "Key @", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_3, InputEvent.SHIFT_DOWN_MASK), "Key #", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_4, InputEvent.SHIFT_DOWN_MASK), "Key $", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_5, InputEvent.SHIFT_DOWN_MASK), "Key %", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_6, InputEvent.SHIFT_DOWN_MASK), "Key ^", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_7, InputEvent.SHIFT_DOWN_MASK), "Key &", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_8, InputEvent.SHIFT_DOWN_MASK), "Key *", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_9, InputEvent.SHIFT_DOWN_MASK), "Key (", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_0, InputEvent.SHIFT_DOWN_MASK), "Key )", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_MINUS, InputEvent.SHIFT_DOWN_MASK), "Key _", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_EQUALS, InputEvent.SHIFT_DOWN_MASK), "Key +", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_Q, InputEvent.SHIFT_DOWN_MASK), "Key Q", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_W, InputEvent.SHIFT_DOWN_MASK), "Key W", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_E, InputEvent.SHIFT_DOWN_MASK), "Key E", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_R, InputEvent.SHIFT_DOWN_MASK), "Key R", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_T, InputEvent.SHIFT_DOWN_MASK), "Key T", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_Y, InputEvent.SHIFT_DOWN_MASK), "Key Y", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_U, InputEvent.SHIFT_DOWN_MASK), "Key U", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_I, InputEvent.SHIFT_DOWN_MASK), "Key I", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_O, InputEvent.SHIFT_DOWN_MASK), "Key O", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_P, InputEvent.SHIFT_DOWN_MASK), "Key P", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_OPEN_BRACKET, InputEvent.SHIFT_DOWN_MASK), "Key {", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_CLOSE_BRACKET, InputEvent.SHIFT_DOWN_MASK), "Key }", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_BACK_SLASH, InputEvent.SHIFT_DOWN_MASK), "Key |", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_A, InputEvent.SHIFT_DOWN_MASK), "Key A", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.SHIFT_DOWN_MASK), "Key S", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_D, InputEvent.SHIFT_DOWN_MASK), "Key D", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_F, InputEvent.SHIFT_DOWN_MASK), "Key F", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_G, InputEvent.SHIFT_DOWN_MASK), "Key G", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_H, InputEvent.SHIFT_DOWN_MASK), "Key H", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_J, InputEvent.SHIFT_DOWN_MASK), "Key J", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_K, InputEvent.SHIFT_DOWN_MASK), "Key K", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_L, InputEvent.SHIFT_DOWN_MASK), "Key L", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_SEMICOLON, InputEvent.SHIFT_DOWN_MASK), "Key :", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_QUOTE, InputEvent.SHIFT_DOWN_MASK), "Key Double Quote", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_Z, InputEvent.SHIFT_DOWN_MASK), "Key Z", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_X, InputEvent.SHIFT_DOWN_MASK), "Key X", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.SHIFT_DOWN_MASK), "Key C", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_V, InputEvent.SHIFT_DOWN_MASK), "Key V", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_B, InputEvent.SHIFT_DOWN_MASK), "Key B", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_N, InputEvent.SHIFT_DOWN_MASK), "Key N", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_M, InputEvent.SHIFT_DOWN_MASK), "Key M", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_COMMA, InputEvent.SHIFT_DOWN_MASK), "Key <", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_PERIOD, InputEvent.SHIFT_DOWN_MASK), "Key >", actionListener);
-        registerKeyBinding(KeyStroke.getKeyStroke(KeyEvent.VK_SLASH, InputEvent.SHIFT_DOWN_MASK), "Key ?", actionListener);
+        bindKeys();
 
         try {
             AudioInputStream audioInputStreamCorrect = AudioSystem.getAudioInputStream(Objects.requireNonNull(getClass().getResource("/sounds/keyCorrect.wav")));
@@ -216,18 +114,28 @@ public class GamePanel extends JPanel {
     }
 
     /**
-     * Registers key binding
-     *
-     * @param keyStroke key name
-     * @param name      binding comment
-     * @param action    action to perform
+     * Registers key bindings for all needed keys
      */
-    private void registerKeyBinding(KeyStroke keyStroke, String name, Action action) {
+    private void bindKeys() {
+        Action actionListener = new AbstractAction() {
+            public void actionPerformed(ActionEvent actionEvent) {
+                checkKeyPressed(actionEvent.getActionCommand());
+            }
+        };
+
         InputMap im = getInputMap(WHEN_IN_FOCUSED_WINDOW);
         ActionMap am = getActionMap();
 
-        im.put(keyStroke, name);
-        am.put(name, action);
+        for (Language language : GameContext.getAvailableLanguages()) {
+            for (char key : GameContext.getAllKeys(language)) {
+                KeyStroke keyStroke = KeyStroke.getKeyStroke(key);
+                if (im.get(keyStroke) == null) {
+                    String name = "Key '" + key + "'";
+                    im.put(keyStroke, name);
+                    am.put(name, actionListener);
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/java/ua/com/yatran/panels/GamePanel.java
+++ b/src/main/java/ua/com/yatran/panels/GamePanel.java
@@ -13,6 +13,7 @@ import javax.sound.sampled.*;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
 import java.io.IOException;
 import java.util.Calendar;
 import java.util.Objects;
@@ -34,7 +35,7 @@ public class GamePanel extends JPanel {
         this.rankingPanel = rankingPanel;
         this.setLayout(null);
 
-        bindKeys();
+        registerKeysBinding();
 
         try {
             AudioInputStream audioInputStreamCorrect = AudioSystem.getAudioInputStream(Objects.requireNonNull(getClass().getResource("/sounds/keyCorrect.wav")));
@@ -116,7 +117,7 @@ public class GamePanel extends JPanel {
     /**
      * Registers key bindings for all needed keys
      */
-    private void bindKeys() {
+    private void registerKeysBinding() {
         Action actionListener = new AbstractAction() {
             public void actionPerformed(ActionEvent actionEvent) {
                 checkKeyPressed(actionEvent.getActionCommand());
@@ -136,6 +137,10 @@ public class GamePanel extends JPanel {
                 }
             }
         }
+
+        //Add the Space key separately as it doesn't present in the key list
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_SPACE, 0), "Key Space");
+        am.put("Key Space", actionListener);
     }
 
     /**
@@ -165,7 +170,7 @@ public class GamePanel extends JPanel {
      */
     private void checkKeyPressed(String key) {
         if (letters.length > currentLetterIndex) {
-            //There are keys to press existing
+            //The pressed key is existing
             if (letters[currentLetterIndex].equals(key)) {
                 //The correct key was pressed - add scores
                 if (GameContext.getSettings().isSoundOn()) {


### PR DESCRIPTION
Fixed the issue #3 

The problem was the incorrect binding of Ukrainian letters such as `х, ї, ж, є, б, ю` in the Windows operating system. I solved this problem by binding to Unicode character values instead of `KeyEvent` class constants. 

Special thanks to [Oleksandr](https://dou.ua/forums/topic/42203/?ref=email&utm_source=reply-comment&utm_medium=email&utm_campaign=15122024#2912023) for the idea of how not to wait for a Windows PC, and to [Bald](https://github.com/Bald1nh0) for the hardware he made available!